### PR TITLE
Migrate folder endpoints to Convex

### DIFF
--- a/backend/ai_tutor/routers/folders.py
+++ b/backend/ai_tutor/routers/folders.py
@@ -1,10 +1,10 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
-from supabase import Client, PostgrestAPIResponse
 from gotrue.types import User
 from typing import List
 from uuid import UUID
 
-from ai_tutor.dependencies import get_supabase_client
+from ai_tutor.dependencies import get_convex_client
+from ai_tutor.services.convex_client import ConvexClient
 from ai_tutor.auth import verify_token
 from ai_tutor.api_models import FolderCreateRequest, FolderResponse, FolderListResponse
 
@@ -18,30 +18,17 @@ router = APIRouter(
 async def create_folder(
     folder_data: FolderCreateRequest,
     request: Request,
-    supabase: Client = Depends(get_supabase_client)
+    convex: ConvexClient = Depends(get_convex_client)
 ):
     """Creates a new folder for the authenticated user."""
     user: User = request.state.user
     try:
-        response: PostgrestAPIResponse = supabase.table("folders").insert({
-            "user_id": user.id,
-            "name": folder_data.name
-        }).execute()
-
-        # Check if data is a list and not empty
-        if response.data and isinstance(response.data, list) and len(response.data) > 0:
-            inserted_folder = response.data[0] # Get the first (and only) inserted item
-            # Ensure created_at is stringified for the Pydantic model
-            return {
-                "id": str(inserted_folder["id"]),
-                "name": inserted_folder["name"],
-                "created_at": str(inserted_folder.get("created_at"))
-            }
-        else:
-            # Log potential error if available, or just the response
-            error_details = getattr(response, 'error', 'No specific error details')
-            print(f"Error creating folder: {error_details}")
-            raise HTTPException(status_code=400, detail=f"Failed to create folder: {response.error.message if response.error else 'Unknown error'}")
+        data = await convex.mutation("createFolder", {"name": folder_data.name})
+        return {
+            "id": str(data.get("id")),
+            "name": data.get("name"),
+            "created_at": str(data.get("created_at")),
+        }
     except Exception as e:
         print(f"Exception creating folder: {e}")
         raise HTTPException(status_code=500, detail=f"Database error during folder creation: {str(e)}")
@@ -49,31 +36,17 @@ async def create_folder(
 @router.get("/", response_model=None)
 async def list_folders(
     request: Request,
-    supabase: Client = Depends(get_supabase_client)
+    convex: ConvexClient = Depends(get_convex_client)
 ):
     """Lists all folders belonging to the authenticated user."""
     user: User = request.state.user
     try:
-        response: PostgrestAPIResponse = supabase.table("folders").select("id, name, created_at").eq("user_id", user.id).order("created_at", desc=True).execute()
-
-        if response.data:
-            # Convert created_at to string for each folder
-            folders = [
-                {
-                    "id": str(item["id"]),
-                    "name": item["name"],
-                    "created_at": str(item["created_at"]),
-                }
-                for item in response.data
-            ]
-            return {"folders": folders}
-        elif isinstance(response.data, list) and not response.data:
-            return {"folders": []}
-        else:
-            # Handle unexpected response structure or potential error not caught by exception
-            print(f"Unexpected response structure or error listing folders: {response}") # Log the whole response
-            raise HTTPException(status_code=500, detail="Failed to list folders due to unexpected response.")
-
+        data = await convex.query("listFolders", {})
+        folders = [
+            {"id": str(item.get("id")), "name": item.get("name"), "created_at": str(item.get("created_at"))}
+            for item in (data or [])
+        ]
+        return {"folders": folders}
     except Exception as e:
         print(f"Exception listing folders: {e}")
         raise HTTPException(status_code=500, detail=f"Database error listing folders: {str(e)}")

--- a/backend/ai_tutor/services/convex_client.py
+++ b/backend/ai_tutor/services/convex_client.py
@@ -1,0 +1,24 @@
+import httpx
+
+class ConvexClient:
+    """Minimal async HTTP client for Convex mutations and queries."""
+
+    def __init__(self, base_url: str, token: str | None = None):
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+
+    async def _call(self, path: str, name: str, args: dict | None) -> dict:
+        url = f"{self.base_url}/{path}/{name}"
+        headers = {}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(url, json=args or {}, headers=headers)
+            resp.raise_for_status()
+            return resp.json()
+
+    async def mutation(self, name: str, args: dict | None = None) -> dict:
+        return await self._call("mutation", name, args)
+
+    async def query(self, name: str, args: dict | None = None) -> dict:
+        return await self._call("query", name, args)

--- a/backend/tests/test_folders_convex.py
+++ b/backend/tests/test_folders_convex.py
@@ -1,0 +1,164 @@
+import pytest
+from fastapi.testclient import TestClient
+from uuid import uuid4
+
+# Fixture to provide TestClient with Convex dependency overrides
+@pytest.fixture
+def client_with_dummy_convex(monkeypatch):
+    import types, sys
+
+    # Patch openai to avoid loading real client
+    fake_openai = types.ModuleType("openai")
+    class _DummyAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+        async def close(self):
+            pass
+        @property
+        def is_closed(self):
+            return False
+    fake_openai.AsyncOpenAI = _DummyAsyncClient
+    fake_openai.NOT_GIVEN = object()
+    types_pkg = types.ModuleType("openai.types")
+    responses_pkg = types.ModuleType("openai.types.responses")
+    # Add placeholder classes expected by `agents` package
+    class _Dummy:
+        pass
+    for name in [
+        "Response",
+        "ResponseComputerToolCall",
+        "ResponseFileSearchToolCall",
+        "ResponseFunctionToolCall",
+        "ResponseFunctionWebSearch",
+        "ResponseInputItemParam",
+        "ResponseOutputItem",
+        "ResponseOutputMessage",
+        "ResponseOutputRefusal",
+        "ResponseOutputText",
+        "ResponseStreamEvent",
+    ]:
+        setattr(responses_pkg, name, _Dummy)
+    types_pkg.responses = responses_pkg
+    fake_openai.types = types_pkg
+    sys.modules.setdefault("openai.types", types_pkg)
+    sys.modules.setdefault("openai.types.responses", responses_pkg)
+    base_client = types.ModuleType("openai._base_client")
+    class _DummyWrapper:
+        def __del__(self):
+            pass
+    base_client.AsyncHttpxClientWrapper = _DummyWrapper
+    fake_openai._base_client = base_client
+    sys.modules.setdefault("openai", fake_openai)
+    sys.modules.setdefault("openai._base_client", base_client)
+
+    # Provide stub supabase module so dependencies import succeeds
+    fake_supabase = types.ModuleType("supabase")
+    class _DummyClient:
+        pass
+    def _create_client(*args, **kwargs):
+        return _DummyClient()
+    fake_supabase.Client = _DummyClient
+    fake_supabase.create_client = _create_client
+    sys.modules.setdefault("supabase", fake_supabase)
+
+    fake_gotrue = types.ModuleType("gotrue")
+    types_module = types.ModuleType("gotrue.types")
+    class _DummyUser:
+        pass
+    types_module.User = _DummyUser
+    fake_gotrue.types = types_module
+    sys.modules.setdefault("gotrue", fake_gotrue)
+    sys.modules.setdefault("gotrue.types", types_module)
+
+    # Provide minimal api_models used by router
+    from pydantic import BaseModel
+
+    class FolderCreateRequest(BaseModel):
+        name: str
+
+    class FolderResponse(BaseModel):
+        id: str
+        name: str
+        created_at: str
+
+    class FolderListResponse(BaseModel):
+        folders: list[FolderResponse]
+
+    api_models_stub = types.ModuleType("ai_tutor.api_models")
+    api_models_stub.FolderCreateRequest = FolderCreateRequest
+    api_models_stub.FolderResponse = FolderResponse
+    api_models_stub.FolderListResponse = FolderListResponse
+    sys.modules.setdefault("ai_tutor.api_models", api_models_stub)
+
+
+    from fastapi import FastAPI, Request
+    from ai_tutor.dependencies import get_convex_client
+    from ai_tutor.auth import verify_token
+    import importlib.util, pathlib
+    spec = importlib.util.spec_from_file_location(
+        "folders_router_module",
+        pathlib.Path(__file__).resolve().parents[1] / "ai_tutor" / "routers" / "folders.py",
+    )
+    folders_module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(folders_module)
+    folders_router = folders_module.router
+
+    app = FastAPI()
+    app.include_router(folders_router, prefix="/api/v1")
+
+    class DummyConvex:
+        def __init__(self):
+            self.folders = []
+        async def mutation(self, name, args):
+            if name == "createFolder":
+                folder = {
+                    "id": str(uuid4()),
+                    "name": args["name"],
+                    "created_at": "2024-01-01T00:00:00Z",
+                }
+                self.folders.append(folder)
+                return folder
+            raise NotImplementedError
+        async def query(self, name, args):
+            if name == "listFolders":
+                return self.folders
+            raise NotImplementedError
+
+    dummy = DummyConvex()
+
+    async def _override_convex(request: Request):
+        return dummy
+    app.dependency_overrides[get_convex_client] = _override_convex
+
+    async def _fake_verify_token(request: Request):
+        class _User:
+            id = uuid4()
+        request.state.user = _User()
+        return _User()
+    app.dependency_overrides[verify_token] = _fake_verify_token
+
+    yield TestClient(app), dummy
+    app.dependency_overrides.clear()
+
+
+def test_create_and_list_folders(client_with_dummy_convex):
+    client, dummy = client_with_dummy_convex
+
+    resp = client.post(
+        "/api/v1/folders/",
+        json={"name": "My Folder"},
+        headers={"Authorization": "Bearer faketoken"},
+    )
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["name"] == "My Folder"
+    folder_id = data["id"]
+
+    resp = client.get(
+        "/api/v1/folders/",
+        headers={"Authorization": "Bearer faketoken"},
+    )
+    assert resp.status_code == 200
+    folders = resp.json()["folders"]
+    assert any(f["id"] == folder_id for f in folders)


### PR DESCRIPTION
## Summary
- add minimal ConvexClient implementation
- integrate Convex into dependencies
- refactor folder router to use Convex queries/mutations
- add unit test covering folder creation and listing via Convex

## Testing
- `pytest tests/test_folders_convex.py -q`
