### PR TITLE
Convex migration for history APIs

### DIFF
--- a/backend/ai_tutor/dependencies.py
+++ b/backend/ai_tutor/dependencies.py
@@ -2,6 +2,7 @@
 import os
 from fastapi import HTTPException, status
 from supabase import create_client, Client
+from typing import Any
 from dotenv import load_dotenv
 from openai import AsyncOpenAI
 from openai._base_client import AsyncHttpxClientWrapper  # type: ignore
@@ -97,4 +98,27 @@ async def get_redis_client() -> _Redis:
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Redis client is not available. Check backend configuration and logs.",
         )
-    return REDIS_CLIENT 
+    return REDIS_CLIENT
+
+
+# --- Convex Client Stub & Dependency ------------------------------------ #
+
+class ConvexClient:
+    """Minimal Convex client placeholder used by the backend."""
+
+    async def query(self, name: str, args: dict[str, Any]):  # pragma: no cover - runtime impl will override
+        raise NotImplementedError
+
+    async def mutation(self, name: str, args: dict[str, Any]):  # pragma: no cover
+        raise NotImplementedError
+
+
+CONVEX_CLIENT: ConvexClient | None = None
+
+
+async def get_convex_client() -> ConvexClient:
+    """FastAPI dependency providing the Convex client instance."""
+    global CONVEX_CLIENT
+    if CONVEX_CLIENT is None:
+        CONVEX_CLIENT = ConvexClient()
+    return CONVEX_CLIENT

--- a/backend/ai_tutor/routers/sessions.py
+++ b/backend/ai_tutor/routers/sessions.py
@@ -1,11 +1,15 @@
 from fastapi import APIRouter, HTTPException, Depends, Request
-from supabase import Client
+from supabase import Client  # noqa: F401  # Supabase used by other endpoints
+from ai_tutor.dependencies import (
+    get_supabase_client,
+    get_convex_client,
+    ConvexClient,
+)
 from gotrue.types import User  # To type hint the user object
 from uuid import UUID
 from typing import Optional, List, Dict as TDict
 
 from ai_tutor.session_manager import SessionManager
-from ai_tutor.dependencies import get_supabase_client  # Get supabase client dependency
 from ai_tutor.auth import verify_token  # Get auth dependency
 from ai_tutor.api_models import SessionResponse
 
@@ -76,7 +80,7 @@ async def get_session_messages(
     session_id: UUID,
     before_turn_no: Optional[int] = None,
     limit: int = 50,
-    supabase: Client = Depends(get_supabase_client),
+    convex: ConvexClient = Depends(get_convex_client),
 ):
     """Return up to ``limit`` chat messages *before* ``before_turn_no``.
 
@@ -102,25 +106,14 @@ async def get_session_messages(
     # to request.state for parity with other endpoints that rely on it.
     user = request.state.user  # populated by verify_token dependency
 
-    query = (
-        supabase.table("session_messages")
-        .select("turn_no, role, text, payload_json, whiteboard_snapshot_index")
-        .eq("session_id", str(session_id))
+    rows: List[TDict] = await convex.query(
+        "list_session_messages",
+        {
+            "session_id": str(session_id),
+            "before_turn_no": before_turn_no,
+            "limit": limit,
+        },
     )
-
-    if before_turn_no is not None:
-        query = query.lt("turn_no", before_turn_no)  # STRICTLY before
-
-    # Fetch newest first so that LIMIT works as expected, then reverse so the
-    # list is chronological (oldest→newest) for the FE.
-    resp = (
-        query.order("turn_no", desc=True)  # newest → oldest
-        .limit(limit)
-        .execute()
-    )
-
-    rows: List[TDict] = resp.data or []
-    rows.reverse()  # chronological order
 
     # For user rows we only return text; for assistant include payload_json.
     for r in rows:
@@ -138,7 +131,7 @@ async def get_whiteboard_state(
     request: Request,
     session_id: UUID,
     target_snapshot_index: int,
-    supabase: Client = Depends(get_supabase_client),
+    convex: ConvexClient = Depends(get_convex_client),
 ):
     """Return concatenated whiteboard actions for all snapshots with
     ``snapshot_index`` ≤ *target_snapshot_index*.
@@ -149,16 +142,13 @@ async def get_whiteboard_state(
 
     user = request.state.user  # Access to ensure verify_token populated it
 
-    resp = (
-        supabase.table("whiteboard_snapshots")
-        .select("snapshot_index, actions_json")
-        .eq("session_id", str(session_id))
-        .lte("snapshot_index", target_snapshot_index)
-        .order("snapshot_index", desc=False)
-        .execute()
+    rows = await convex.query(
+        "list_whiteboard_snapshots",
+        {
+            "session_id": str(session_id),
+            "target_snapshot_index": target_snapshot_index,
+        },
     )
-
-    rows = resp.data or []
     actions: List[TDict] = []
     for row in rows:
         actions.extend(row.get("actions_json") or [])

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,106 @@
+import sys, types
+
+# Stub supabase package if missing
+if 'supabase' not in sys.modules:
+    supabase = types.ModuleType('supabase')
+    supabase.Client = object
+    def _create_client(*_a, **_k):
+        return types.SimpleNamespace(table=lambda name: None)
+    supabase.create_client = _create_client
+    supabase.PostgrestAPIResponse = object
+    sys.modules['supabase'] = supabase
+
+# Provide minimal openai stub so dependencies can import without API key
+if 'openai' not in sys.modules:
+    openai = types.ModuleType('openai')
+    class _DummyAsyncClient:
+        def __init__(self, *a, **k):
+            pass
+        async def close(self):
+            pass
+        @property
+        def is_closed(self):
+            return False
+    openai.AsyncOpenAI = _DummyAsyncClient  # type: ignore[attr-defined]
+    base_client = types.ModuleType('openai._base_client')
+    class _DummyWrapper:
+        def __del__(self):
+            pass
+    base_client.AsyncHttpxClientWrapper = _DummyWrapper  # type: ignore[attr-defined]
+    openai.NOT_GIVEN = object()
+    # minimal types subpackage
+    types_pkg = types.ModuleType('openai.types')
+    responses_pkg = types.ModuleType('openai.types.responses')
+    responses_pkg.Response = type('Response', (), {})
+    responses_pkg.ResponseComputerToolCall = type('ResponseComputerToolCall', (), {})
+    types_pkg.CompletionUsage = type('CompletionUsage', (), {})
+    types_pkg.responses = responses_pkg
+    openai.types = types_pkg
+    openai._base_client = base_client
+    sys.modules['openai'] = openai
+    sys.modules['openai._base_client'] = base_client
+    sys.modules['openai.types'] = types_pkg
+    sys.modules['openai.types.responses'] = responses_pkg
+
+# Stub pytest_asyncio if missing (used only in skipped tests)
+if 'pytest_asyncio' not in sys.modules:
+    sys.modules['pytest_asyncio'] = types.ModuleType('pytest_asyncio')
+
+# Stub agent_t package for metadata tests
+if 'agent_t' not in sys.modules:
+    agent_t = types.ModuleType('agent_t')
+    services = types.ModuleType('agent_t.services')
+    wb_meta = types.ModuleType('agent_t.services.whiteboard_metadata')
+    wb_meta.Metadata = type('Metadata', (), {})
+    services.whiteboard_metadata = wb_meta
+    agent_t.services = services
+    sys.modules['agent_t'] = agent_t
+    sys.modules['agent_t.services'] = services
+    sys.modules['agent_t.services.whiteboard_metadata'] = wb_meta
+
+# Stub 'agents' package used by analyzer_agent
+if 'agents' not in sys.modules:
+    agents_mod = types.ModuleType('agents')
+    agents_mod.Runner = object
+    agents_mod.RunConfig = object
+    agents_mod.Agent = object
+    agents_mod.ModelProvider = object
+    agents_mod.FileSearchTool = object
+    def _function_tool(*args, **kwargs):
+        def decorator(fn):
+            return fn
+        return decorator
+    agents_mod.function_tool = _function_tool
+    tool_mod = types.ModuleType('agents.tool')
+    tool_mod.FunctionTool = _function_tool
+    agents_mod.tool = tool_mod
+    models_mod = types.ModuleType('agents.models.openai_provider')
+    models_mod.OpenAIProvider = object
+    agents_mod.models = types.SimpleNamespace(openai_provider=models_mod)
+    run_context_mod = types.ModuleType('agents.run_context')
+    run_context_mod.RunContextWrapper = object
+    sys.modules['agents'] = agents_mod
+    sys.modules['agents.models.openai_provider'] = models_mod
+    sys.modules['agents.tool'] = tool_mod
+    sys.modules['agents.run_context'] = run_context_mod
+
+# Stub postgrest package used for APIError
+if 'postgrest.exceptions' not in sys.modules:
+    postgrest_pkg = types.ModuleType('postgrest')
+    exc_mod = types.ModuleType('postgrest.exceptions')
+    class APIError(Exception):
+        pass
+    exc_mod.APIError = APIError
+    postgrest_pkg.exceptions = exc_mod
+    sys.modules['postgrest'] = postgrest_pkg
+    sys.modules['postgrest.exceptions'] = exc_mod
+
+# Minimal gotrue.types.User stub
+if 'gotrue.types' not in sys.modules:
+    gotrue = types.ModuleType('gotrue')
+    types_mod = types.ModuleType('gotrue.types')
+    class User: ...
+    types_mod.User = User
+    gotrue.types = types_mod
+    sys.modules['gotrue'] = gotrue
+    sys.modules['gotrue.types'] = types_mod

--- a/backend/tests/test_phase1_persistence.py
+++ b/backend/tests/test_phase1_persistence.py
@@ -6,66 +6,25 @@ from ai_tutor.context import TutorContext
 from ai_tutor.routers.tutor_ws import _persist_user_message, _persist_assistant_message
 
 
-class _DummyResp:
-    def execute(self):
-        return self
-
-    @property
-    def data(self):
-        return None
-
-
-class _DummyTable:
-    def __init__(self, name: str, store: dict):
-        self._name = name
-        self._store = store.setdefault(name, [])
-        self._pending = None
-
-    # Mimic Supabase ``insert`` chaining API
-    def insert(self, record: dict):
-        self._pending = record
-        return self
-
-    # For select/order/limit in hydrate we ignore; only used in persist tests
-    def select(self, *_args, **_kwargs):
-        return self
-
-    def order(self, *_args, **_kwargs):
-        return self
-
-    def lte(self, *_args, **_kwargs):
-        return self
-
-    def limit(self, *_args, **_kwargs):
-        return self
-
-    def eq(self, *_args, **_kwargs):
-        return self
-
-    def execute(self):
-        if self._pending is not None:
-            self._store.append(self._pending)
-            self._pending = None
-        # return minimal supabase-python like dict
-        return _DummyResp()
-
-
-class DummySupabase:
+class DummyConvex:
     def __init__(self):
-        self._storage: dict[str, list] = {}
+        self.storage: dict[str, list] = {
+            "session_messages": [],
+            "whiteboard_snapshots": [],
+        }
 
-    def table(self, name: str):
-        return _DummyTable(name, self._storage)
-
-    # expose storage for assertions
-    @property
-    def storage(self):
-        return self._storage
+    async def mutation(self, name: str, args: dict):
+        if name == "insert_session_message":
+            self.storage["session_messages"].append(args)
+        elif name == "insert_snapshot":
+            self.storage["whiteboard_snapshots"].append(args)
+        else:
+            raise ValueError(name)
 
 
 @pytest.mark.asyncio
 async def test_persist_user_and_assistant_message_order():
-    supabase = DummySupabase()
+    supabase = DummyConvex()
     ctx = TutorContext(session_id=uuid4(), user_id=uuid4())
 
     # Persist two user messages


### PR DESCRIPTION
## Summary
- switch session history and whiteboard fetch to use Convex
- persist chat history via Convex mutations
- stub Convex client dependency
- adapt unit tests with Convex dummy client

## Testing
- `pytest tests/test_phase1_persistence.py tests/test_phase2_history.py -q` *(fails: ModuleNotFoundError: openai.types)*