### PR TITLE
Integrate Convex into frontend API

### DIFF
--- a/frontend/convex/functions.ts
+++ b/frontend/convex/functions.ts
@@ -1,4 +1,5 @@
-import { query } from "./_generated/server";
+import { query, mutation } from "./_generated/server";
+import { v } from "convex/values";
 
 // Example query function
 export const hello = query({
@@ -6,4 +7,44 @@ export const hello = query({
   handler: async (ctx) => {
     return "Hello from Convex!";
   },
-}); 
+});
+
+// Placeholder folder creation mutation
+export const createFolder = mutation({
+  args: { name: v.string() },
+  handler: async (ctx, { name }) => {
+    const id = await ctx.db.insert("folders", { name });
+    return { id };
+  },
+});
+
+// Fetch all folders for the current user
+export const getFolders = query({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.db.query("folders").collect();
+  },
+});
+
+// Start a new session record
+export const startSession = mutation({
+  args: { folderId: v.id("folders") },
+  handler: async (ctx, { folderId }) => {
+    const sessionId = await ctx.db.insert("sessions", {
+      folderId,
+      createdAt: Date.now(),
+    });
+    return { session_id: sessionId };
+  },
+});
+
+// Fetch messages for a session
+export const fetchSessionMessages = query({
+  args: { sessionId: v.id("sessions") },
+  handler: async (ctx, { sessionId }) => {
+    return await ctx.db
+      .query("session_messages")
+      .withIndex("by_session", (q) => q.eq("sessionId", sessionId))
+      .collect();
+  },
+});

--- a/frontend/convex/schema.ts
+++ b/frontend/convex/schema.ts
@@ -3,5 +3,16 @@ import { v } from "convex/values";
 
 // Define your schema here
 export default defineSchema({
-  // Tables will be defined here
-}); 
+  folders: defineTable({
+    name: v.string(),
+  }),
+  sessions: defineTable({
+    folderId: v.id("folders"),
+    createdAt: v.number(),
+  }),
+  session_messages: defineTable({
+    sessionId: v.id("sessions"),
+    role: v.string(),
+    content: v.string(),
+  }).index("by_session", ["sessionId"]),
+});

--- a/frontend/src/lib/convex.ts
+++ b/frontend/src/lib/convex.ts
@@ -1,3 +1,10 @@
 import { ConvexClient } from "convex/browser";
+import { supabase } from "./supabaseClient";
 
-export const convex = new ConvexClient(process.env.NEXT_PUBLIC_CONVEX_URL!); 
+export const convex = new ConvexClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+
+// Authenticate Convex requests with the current Supabase session
+convex.setAuth(async () => {
+  const { data: { session } } = await supabase.auth.getSession();
+  return session?.access_token ?? null;
+});


### PR DESCRIPTION
## Summary
- connect Convex client to Supabase session
- expose Convex auth in `AuthContext`
- add placeholder Convex schema and functions
- route folder and session APIs through Convex

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'supabase')*