### PR TITLE
[frontend] reuse backend convex schema

### DIFF
--- a/frontend/convex/schema.ts
+++ b/frontend/convex/schema.ts
@@ -1,7 +1,5 @@
-import { defineSchema, defineTable } from "convex/server";
-import { v } from "convex/values";
-
-// Define your schema here
-export default defineSchema({
-  // Tables will be defined here
-}); 
+// Re-export the backend Convex schema so the frontend and backend share
+// a single source of truth. This ensures the generated data model includes
+// all tables defined for the backend when running `npx convex dev` in the
+// `frontend` directory.
+export { default } from "../../convex/schema";


### PR DESCRIPTION
## Summary
- reference the backend `convex/schema.ts` from the frontend so the Convex CLI type generation includes all tables

## Testing
- `pytest -q` *(fails: AttributeError: 'function' object has no attribute 'name')*
- `npm run lint` *(fails: The requested module '@eslint/eslintrc' does not provide an export named 'createConfig')*