### PR TITLE
[convex] fix ts imports

### DIFF
--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -6,6 +6,10 @@
     "jsx": "react-jsx",
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "convex/*": ["../frontend/node_modules/convex/*"]
+    },
     "target": "ESNext",
     "lib": ["ES2021", "dom"],
     "forceConsistentCasingInFileNames": true,

--- a/frontend/convex/tsconfig.json
+++ b/frontend/convex/tsconfig.json
@@ -11,6 +11,11 @@
     "jsx": "react-jsx",
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "convex/*": ["../node_modules/convex/*"],
+      "backend-convex/*": ["../../convex/*"]
+    },
 
     /* These compiler options are required by Convex */
     "target": "ESNext",


### PR DESCRIPTION
## Summary
- add path mappings for `convex` to the Convex tsconfig
- make frontend Convex tsconfig aware of backend Convex schema

## Testing
- `pnpm lint` *(fails: The requested module '@eslint/eslintrc' does not provide an export named 'createConfig')*
- `npx tsc -p frontend/convex/tsconfig.json`
