### PR TITLE
[convex] add basic folder and session functions

### DIFF
--- a/frontend/convex/functions.ts
+++ b/frontend/convex/functions.ts
@@ -30,3 +30,63 @@ export const logInteraction = mutation({
     });
   },
 });
+
+export const createFolder = mutation({
+  args: { name: v.string() },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+    const now = Date.now();
+    const id = await ctx.db.insert("folders", {
+      user_id: identity.subject,
+      name: args.name,
+      created_at: now,
+      updated_at: now,
+    });
+    const folder = await ctx.db.get(id);
+    return folder;
+  },
+});
+
+export const getFolders = query({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return [];
+    return await ctx.db
+      .query("folders")
+      .withIndex("by_user", (q) => q.eq("user_id", identity.subject))
+      .collect();
+  },
+});
+
+export const startSession = mutation({
+  args: { folderId: v.optional(v.string()) },
+  handler: async (ctx, { folderId }) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+    const now = Date.now();
+    const id = await ctx.db.insert("sessions", {
+      user_id: identity.subject,
+      folder_id: folderId ?? undefined,
+      context_data: {},
+      created_at: now,
+      updated_at: now,
+    });
+    return { id };
+  },
+});
+
+export const fetchSessionMessages = query({
+  args: { sessionId: v.string() },
+  handler: async (ctx, { sessionId }) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return [];
+    return await ctx.db
+      .query("session_messages")
+      .withIndex("by_session_created", (q) => q.eq("session_id", sessionId))
+      .order("asc")
+      .collect();
+  },
+});
+


### PR DESCRIPTION
## Summary
- implement createFolder and getFolders queries
- implement startSession and fetchSessionMessages mutations

## Testing
- `pytest -q` *(fails: AttributeError: 'function' object has no attribute 'name')*
- `npm run lint` *(fails: The requested module '@eslint/eslintrc' does not provide an export named 'createConfig')*