### PR TITLE
[convex] fix path mapping for convex auth

### DIFF
--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -8,14 +8,17 @@
     "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
     "paths": {
-      "convex/*": ["../frontend/node_modules/convex/*"]
+      "convex/*": ["../frontend/node_modules/convex/*"],
+      "@convex-dev/auth/*": ["../frontend/node_modules/@convex-dev/auth/*"]
     },
     "target": "ESNext",
     "lib": ["ES2021", "dom"],
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
     "isolatedModules": true,
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node"],
+    "typeRoots": ["../frontend/node_modules/@types"]
   },
   "include": ["./**/*"],
   "exclude": ["./_generated"]


### PR DESCRIPTION
## Summary
- add path mapping for `@convex-dev/auth` and configure node typings in `convex/tsconfig.json`

## Testing
- `tsc --noEmit --project convex/tsconfig.json`
- `pnpm lint` *(fails: The requested module '@eslint/eslintrc' does not provide an export named 'createConfig')*
- `pytest` *(fails: 7 errors during collection)*