### PR TITLE
[frontend] wrap app with AuthProvider

### DIFF
--- a/frontend/src/app/ConvexClientProvider.tsx
+++ b/frontend/src/app/ConvexClientProvider.tsx
@@ -5,6 +5,7 @@ import { useAuthToken } from "@convex-dev/auth/react";
 import { ConvexReactClient } from "convex/react";
 import { ReactNode, useEffect } from "react";
 import { setAuthToken } from "@/lib/authToken";
+import { AuthProvider } from "@/contexts/AuthContext";
 
 const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
 
@@ -19,8 +20,10 @@ function TokenSync() {
 export function ConvexClientProvider({ children }: { children: ReactNode }) {
   return (
     <ConvexAuthNextjsProvider client={convex}>
-      <TokenSync />
-      {children}
+      <AuthProvider>
+        <TokenSync />
+        {children}
+      </AuthProvider>
     </ConvexAuthNextjsProvider>
   );
 }


### PR DESCRIPTION
## Summary
- fix auth provider wiring by wrapping `AuthProvider` around `<TokenSync />`

## Testing
- `pnpm lint` *(fails: The requested module '@eslint/eslintrc' does not provide an export named 'createConfig')*
- `pytest` *(fails: AttributeError 'function' object has no attribute 'name')*