### PR TITLE
[frontend] fix tsconfig for Convex auth

### DIFF
--- a/frontend/convex/tsconfig.json
+++ b/frontend/convex/tsconfig.json
@@ -14,6 +14,7 @@
     "baseUrl": ".",
     "paths": {
       "convex/*": ["../node_modules/convex/*"],
+      "@convex-dev/auth/*": ["../node_modules/@convex-dev/auth/*"],
       "backend-convex/*": ["../../convex/*"]
     },
 


### PR DESCRIPTION
## Summary
- add missing path for `@convex-dev/auth` in Convex function tsconfig

## Testing
- `npm run lint` *(fails: The requested module '@eslint/eslintrc' does not provide an export named 'createConfig')*