### PR TITLE
[frontend] export backend auth for convex

### DIFF
--- a/frontend/convex/auth.config.ts
+++ b/frontend/convex/auth.config.ts
@@ -1,0 +1,1 @@
+export { default } from "backend-convex/auth.config";

--- a/frontend/convex/auth.ts
+++ b/frontend/convex/auth.ts
@@ -1,0 +1,1 @@
+export * from "backend-convex/auth";

--- a/frontend/convex/http.ts
+++ b/frontend/convex/http.ts
@@ -1,0 +1,1 @@
+export { default } from "backend-convex/http";


### PR DESCRIPTION
## Summary
- re-export backend auth Convex functions for the frontend
- allow `npx convex dev` in `frontend` to expose auth routes

## Testing
- `pytest -q` *(fails: AttributeError 'function' object has no attribute 'name')*
- `npm run lint` *(fails: The requested module '@eslint/eslintrc' does not provide an export named 'createConfig')*