### PR TITLE
[frontend] enable password auth provider

### DIFF
--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -1,5 +1,6 @@
 import { convexAuth } from "@convex-dev/auth/server";
+import Password from "@convex-dev/auth/providers/Password";
 
 export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
-  providers: [],
+  providers: [Password],
 });


### PR DESCRIPTION
## Summary
- register Password provider with Convex auth

## Testing
- `pytest -q` *(fails: AttributeError: 'function' object has no attribute 'name')*
- `pnpm lint` *(fails: The requested module '@eslint/eslintrc' does not provide an export named 'createConfig')*