### PR TITLE
[convex] fix Password import path

### DIFF
--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -1,5 +1,5 @@
 import { convexAuth } from "@convex-dev/auth/server";
-import Password from "@convex-dev/auth/providers/Password";
+import { Password } from "@convex-dev/auth/providers/Password";
 
 export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
   providers: [Password],

--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -9,7 +9,7 @@
     "baseUrl": ".",
     "paths": {
       "convex/*": ["../frontend/node_modules/convex/*"],
-      "@convex-dev/auth/*": ["../frontend/node_modules/@convex-dev/auth/*"]
+      "@convex-dev/auth/*": ["../frontend/node_modules/@convex-dev/auth/dist/*"]
     },
     "target": "ESNext",
     "lib": ["ES2021", "dom"],

--- a/frontend/convex/tsconfig.json
+++ b/frontend/convex/tsconfig.json
@@ -14,7 +14,7 @@
     "baseUrl": ".",
     "paths": {
       "convex/*": ["../node_modules/convex/*"],
-      "@convex-dev/auth/*": ["../node_modules/@convex-dev/auth/*"],
+      "@convex-dev/auth/*": ["../node_modules/@convex-dev/auth/dist/*"],
       "backend-convex/*": ["../../convex/*"]
     },
 


### PR DESCRIPTION
## Summary
- fix import for Password provider
- update tsconfig paths for convex auth

## Testing
- `npx --yes tsc -p convex/tsconfig.json`
- `pytest -q` *(fails: AttributeError: 'function' object has no attribute 'name')*
- `pnpm lint` *(fails: The requested module '@eslint/eslintrc' does not provide an export named 'createConfig')*