### PR TITLE
[frontend] enforce password length

### DIFF
--- a/frontend/src/components/AuthForm.tsx
+++ b/frontend/src/components/AuthForm.tsx
@@ -20,6 +20,16 @@ const AuthForm: React.FC = () => {
     const handleAuth = async (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
         setLoading(true);
+
+        if (password.length < 8) {
+            toast({
+                title: "Password too short",
+                description: "Password must be at least 8 characters long.",
+                variant: "destructive",
+            });
+            setLoading(false);
+            return;
+        }
         try {
             if (isSignUp) {
                 await signIn('password', { flow: 'signUp', email, password });


### PR DESCRIPTION
## Summary
- require passwords to be at least 8 characters in the auth form

## Testing
- `pnpm lint` *(fails: The requested module '@eslint/eslintrc' does not provide an export named 'createConfig')*
- `pytest` *(fails: 7 errors during collection)*