### PR TITLE
[frontend] reuse convex client instance

### DIFF
--- a/frontend/src/app/ConvexClientProvider.tsx
+++ b/frontend/src/app/ConvexClientProvider.tsx
@@ -2,12 +2,10 @@
 
 import { ConvexAuthNextjsProvider } from "@convex-dev/auth/nextjs";
 import { useAuthToken } from "@convex-dev/auth/react";
-import { ConvexReactClient } from "convex/react";
 import { ReactNode, useEffect } from "react";
 import { setAuthToken } from "@/lib/authToken";
 import { AuthProvider } from "@/contexts/AuthContext";
-
-const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+import { convex } from "@/lib/convex";
 
 function TokenSync() {
   const token = useAuthToken();


### PR DESCRIPTION
## Summary
- import the same `ConvexReactClient` used in the provider

## Testing
- `pnpm lint` *(fails: The requested module '@eslint/eslintrc' does not provide an export named 'createConfig')*
- `pytest` *(fails: 7 errors during collection)*