### PR TITLE
[frontend] fix startSession response shape

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -53,7 +53,8 @@ apiClient.interceptors.response.use(
 export const startSession = async (folderId: string): Promise<StartSessionResponse> => {
   try {
     console.log(`Starting new session for folder ${folderId} via Convex...`);
-    return await convex.mutation(convexApi.functions.startSession, { folderId });
+    const res = await convex.mutation(convexApi.functions.startSession, { folderId });
+    return { session_id: res.id as string, message: 'Session started' };
   } catch (error) {
     console.error('Error starting session via Convex:', error);
     throw error; // Re-throw for handling in UI


### PR DESCRIPTION
## Summary
- adapt `startSession` to map Convex result to expected keys

## Testing
- `pnpm lint` *(fails: The requested module '@eslint/eslintrc' does not provide an export named 'createConfig')*
- `pytest` *(fails: multiple import errors)*