### PR TITLE
[convex] add node proxy server setup

### DIFF
--- a/convex/.env.example
+++ b/convex/.env.example
@@ -1,0 +1,4 @@
+# Convex deployment URL
+CONVEX_URL="https://my-convex-deployment.convex.cloud"
+# Port to run the local Node proxy server
+PORT=4000

--- a/convex/README.md
+++ b/convex/README.md
@@ -18,3 +18,19 @@ The tables mirror the previous Supabase schema and include:
 - `concept_graph`
 
 Indexes approximate the ones previously defined in Postgres.
+
+## Local Node Service
+
+A simple proxy server is provided to forward requests to your Convex deployment. Configure it by creating a `.env` file:
+
+```
+cp convex/.env.example convex/.env
+```
+
+Edit `CONVEX_URL` to point at your Convex deployment. Then run the server with your preferred TypeScript runner:
+
+```
+node convex/server.ts
+```
+
+The server listens on the port specified in the `PORT` variable (default `4000`).

--- a/convex/server.ts
+++ b/convex/server.ts
@@ -1,0 +1,30 @@
+import http from 'http';
+import https from 'https';
+
+const convexUrl = process.env.CONVEX_URL || 'http://localhost:3100';
+const port = Number(process.env.PORT || 4000);
+
+const target = new URL(convexUrl);
+const client = target.protocol === 'https:' ? https : http;
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url || '/', target);
+  const options: http.RequestOptions = {
+    hostname: url.hostname,
+    port: url.port || (url.protocol === 'https:' ? 443 : 80),
+    path: url.pathname + url.search,
+    method: req.method,
+    headers: req.headers,
+  };
+
+  const proxyReq = client.request(options, (proxyRes) => {
+    res.writeHead(proxyRes.statusCode || 502, proxyRes.headers);
+    proxyRes.pipe(res);
+  });
+
+  req.pipe(proxyReq);
+});
+
+server.listen(port, () => {
+  console.log(`Convex proxy server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add simple Node proxy server in `convex/`
- add example environment file for Convex URL and port
- document how to run the local Node service

## Testing
- `pytest -q` *(fails: AttributeError: 'function' object has no attribute 'name')*
- `pnpm lint` *(fails: The requested module '@eslint/eslintrc' does not provide an export named 'createConfig')*