### PR TITLE
[convex] port session manager to TS

### DIFF
--- a/convex/sessionManager.test.ts
+++ b/convex/sessionManager.test.ts
@@ -1,0 +1,40 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { SessionManager } from './sessionManager';
+
+// Helper to create a mock fetch function
+function mockFetch(expectedUrl: string, expectedPayload: any, response: any) {
+  return async (url: string, options: any) => {
+    assert.strictEqual(url, expectedUrl);
+    assert.ok(options);
+    assert.strictEqual(options.method, 'POST');
+    const body = JSON.parse(options.body);
+    assert.deepStrictEqual(body, expectedPayload);
+    return new Response(JSON.stringify(response), { status: 200 });
+  };
+}
+
+test('createSession sends POST request', async () => {
+  const sm = new SessionManager('https://api', 'key');
+  const payload = { userId: 'u1', context: {}, folderId: null };
+  globalThis.fetch = mockFetch('https://api/createSession', payload, { id: 's1' }) as any;
+  const id = await sm.createSession('u1');
+  assert.strictEqual(id, 's1');
+});
+
+test('updateSessionContext sends POST request', async () => {
+  const sm = new SessionManager('https://api', 'k');
+  const ctx = { foo: 'bar' };
+  const payload = { sessionId: 's', userId: 'u', context: ctx };
+  globalThis.fetch = mockFetch('https://api/updateSessionContext', payload, {}) as any;
+  const ok = await sm.updateSessionContext('s', 'u', ctx);
+  assert.ok(ok);
+});
+
+test('getSessionContext handles 404', async () => {
+  const sm = new SessionManager('https://api', 'k');
+  globalThis.fetch = async () => new Response('', { status: 404 });
+  const result = await sm.getSessionContext('s', 'u');
+  assert.strictEqual(result, null);
+});
+

--- a/convex/sessionManager.ts
+++ b/convex/sessionManager.ts
@@ -1,0 +1,55 @@
+export interface SessionContext {
+  [key: string]: any;
+}
+
+export class SessionManager {
+  constructor(private baseUrl: string, private adminKey: string) {}
+
+  private headers() {
+    return {
+      Authorization: `Bearer ${this.adminKey}`,
+      'Content-Type': 'application/json',
+    };
+  }
+
+  async createSession(userId: string, folderId?: string, context: SessionContext = {}): Promise<string> {
+    const payload = { userId, context, folderId: folderId ?? null };
+    const res = await fetch(`${this.baseUrl}/createSession`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to create session: ${res.status}`);
+    }
+    const data = await res.json();
+    return data.id as string;
+  }
+
+  async getSessionContext(sessionId: string, userId: string): Promise<SessionContext | null> {
+    const params = new URLSearchParams({ sessionId, userId });
+    const res = await fetch(`${this.baseUrl}/getSessionContext?${params}`, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${this.adminKey}` },
+    });
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      throw new Error(`Failed to fetch context: ${res.status}`);
+    }
+    const data = await res.json();
+    return (data.context as SessionContext) ?? null;
+  }
+
+  async updateSessionContext(sessionId: string, userId: string, context: SessionContext): Promise<boolean> {
+    const payload = { sessionId, userId, context };
+    const res = await fetch(`${this.baseUrl}/updateSessionContext`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to update context: ${res.status}`);
+    }
+    return res.status === 200;
+  }
+}


### PR DESCRIPTION
## Summary
- add a TypeScript SessionManager for Convex HTTP endpoints
- provide unit tests for the new manager

## Testing
- `node --test /tmp/convex-dist/sessionManager.test.js`
- `pnpm lint` *(fails: The requested module '@eslint/eslintrc' does not provide an export named 'createConfig')*