### PR TITLE
[convex] Add board summary and whiteboard APIs

### DIFF
--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -162,3 +162,147 @@ export const getSessionContext = query({
     return { context: session.context_data };
   },
 });
+import { createClient } from 'redis';
+import * as Y from 'yjs';
+
+const REDIS_KEY_PREFIX = 'yjs:snapshot:';
+
+export const getBoardSummary = query({
+  args: { sessionId: v.id("sessions") },
+  handler: async (ctx, { sessionId }) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+    const session = await ctx.db.get(sessionId);
+    if (!session || session.user_id !== identity.subject) {
+      throw new Error("Session not found");
+    }
+
+    const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
+    const client = createClient({ url: redisUrl });
+    await client.connect();
+    const redisKey = `${REDIS_KEY_PREFIX}${sessionId}`;
+    const snapshot = (await client.getBuffer(redisKey)) as Buffer | null;
+    await client.quit();
+
+    if (!snapshot) {
+      return {
+        counts: { by_kind: {}, by_owner: {} },
+        learner_question_tags: [],
+        concept_clusters: [],
+        ephemeralSummary: {
+          activeHighlights: 0,
+          activeQuestionTags: [],
+          recentPointer: null,
+        },
+      };
+    }
+
+    const ydoc = new Y.Doc();
+    try {
+      Y.applyUpdate(ydoc, new Uint8Array(snapshot));
+    } catch (err) {
+      return { error: 'failed_to_decode_snapshot', detail: String(err) };
+    }
+
+    const objMap = ydoc.getMap<any>('objects');
+    const objects = Array.from(objMap.values());
+    const byKind: Record<string, number> = {};
+    const byOwner: Record<string, number> = {};
+    const learnerTags: any[] = [];
+    const conceptBoxes: Record<string, Array<[number, number, number, number]>> = {};
+
+    for (const spec of objects) {
+      const kind = spec?.kind ?? 'unknown';
+      const owner = spec?.metadata?.source ?? 'unknown';
+      byKind[kind] = (byKind[kind] || 0) + 1;
+      byOwner[owner] = (byOwner[owner] || 0) + 1;
+
+      const md = spec?.metadata ?? {};
+      if (md.role === 'question_tag') {
+        learnerTags.push({ id: spec.id, x: spec.x, y: spec.y, meta: md });
+      }
+      const concept = md.concept;
+      if (concept) {
+        const x = Number(spec.x ?? 0);
+        const y = Number(spec.y ?? 0);
+        const w = Number(spec.width ?? 0);
+        const h = Number(spec.height ?? 0);
+        (conceptBoxes[concept] ||= []).push([x, y, x + w, y + h]);
+      }
+    }
+
+    const conceptClusters = Object.entries(conceptBoxes).map(([concept, boxes]) => {
+      const minX = Math.min(...boxes.map((b) => b[0]));
+      const minY = Math.min(...boxes.map((b) => b[1]));
+      const maxX = Math.max(...boxes.map((b) => b[2]));
+      const maxY = Math.max(...boxes.map((b) => b[3]));
+      return { concept, bbox: [minX, minY, maxX, maxY], count: boxes.length };
+    });
+
+    const ephMap = ydoc.getMap<any>('ephemeral');
+    const ephObjs = Array.from(ephMap.values());
+    const activeHighlights = ephObjs.filter((s) => s.kind === 'highlight_stroke').length;
+    const activeQuestionTags = ephObjs
+      .filter((s) => s.kind === 'question_tag')
+      .map((s) => ({ id: s.id, linkedObjectId: s.metadata?.linkedObjectId }));
+    let recentPointer: any = null;
+    const pings = ephObjs.filter((s) => s.kind === 'pointer_ping');
+    if (pings.length > 0) {
+      const latest = pings.reduce((a, b) =>
+        (a.metadata?.expiresAt || 0) > (b.metadata?.expiresAt || 0) ? a : b
+      );
+      recentPointer = { x: latest.x, y: latest.y, meta: latest.metadata };
+    }
+
+    return {
+      counts: { by_kind: byKind, by_owner: byOwner },
+      learner_question_tags: learnerTags,
+      concept_clusters: conceptClusters,
+      ephemeralSummary: {
+        activeHighlights,
+        activeQuestionTags,
+        recentPointer,
+      },
+    };
+  },
+});
+
+export const insertSnapshot = mutation({
+  args: {
+    sessionId: v.id('sessions'),
+    snapshotIndex: v.number(),
+    actionsJson: v.any(),
+  },
+  handler: async (ctx, { sessionId, snapshotIndex, actionsJson }) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error('Not authenticated');
+    const session = await ctx.db.get(sessionId);
+    if (!session || session.user_id !== identity.subject) {
+      throw new Error('Session not found');
+    }
+    await ctx.db.insert('whiteboard_snapshots', {
+      session_id: sessionId,
+      snapshot_index: snapshotIndex,
+      actions_json: actionsJson,
+      created_at: Date.now(),
+    });
+  },
+});
+
+export const getWhiteboardSnapshots = query({
+  args: { sessionId: v.id('sessions'), maxIndex: v.optional(v.number()) },
+  handler: async (ctx, { sessionId, maxIndex }) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return [];
+    const session = await ctx.db.get(sessionId);
+    if (!session || session.user_id !== identity.subject) return [];
+    let q = ctx.db
+      .query('whiteboard_snapshots')
+      .withIndex('by_session_snapshot', (q) => q.eq('session_id', sessionId));
+    if (maxIndex !== undefined) {
+      q = q.lte('snapshot_index', maxIndex);
+    }
+    q = q.order('asc');
+    return await q.collect();
+  },
+});

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -113,4 +113,46 @@ http.route({
   }),
 });
 
+http.route({
+  path: "/getBoardSummary",
+  method: "GET",
+  handler: httpAction(async ({ runQuery }, request) => {
+    const url = new URL(request.url);
+    const sessionId = url.searchParams.get("sessionId");
+    if (!sessionId) return new Response("Missing sessionId", { status: 400 });
+    const summary = await runQuery(api.functions.getBoardSummary, { sessionId });
+    return new Response(JSON.stringify(summary), { status: 200 });
+  }),
+});
+
+http.route({
+  path: "/insertSnapshot",
+  method: "POST",
+  handler: httpAction(async ({ runMutation }, request) => {
+    const body = await request.json();
+    await runMutation(api.functions.insertSnapshot, {
+      sessionId: body.sessionId,
+      snapshotIndex: body.snapshotIndex,
+      actionsJson: body.actionsJson,
+    });
+    return new Response(null, { status: 200 });
+  }),
+});
+
+http.route({
+  path: "/getWhiteboardSnapshots",
+  method: "GET",
+  handler: httpAction(async ({ runQuery }, request) => {
+    const url = new URL(request.url);
+    const sessionId = url.searchParams.get("sessionId");
+    if (!sessionId) return new Response("Missing sessionId", { status: 400 });
+    const maxIndex = url.searchParams.get("maxIndex");
+    const rows = await runQuery(api.functions.getWhiteboardSnapshots, {
+      sessionId,
+      maxIndex: maxIndex ? Number(maxIndex) : undefined,
+    });
+    return new Response(JSON.stringify(rows), { status: 200 });
+  }),
+});
+
 export default http;


### PR DESCRIPTION
## Summary
- implement `getBoardSummary`, `insertSnapshot`, and `getWhiteboardSnapshots` in Convex
- expose HTTP routes for the new functions

## Testing
- `npm run lint` *(fails: The requested module '@eslint/eslintrc' does not provide an export named 'createConfig')*
- `node --test convex/sessionManager.test.ts` *(fails: Unknown file extension .ts)*