### PR TITLE
[convex] fix TypeScript build errors

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -1,0 +1,40 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+import type * as auth from "../auth.js";
+import type * as functions from "../functions.js";
+import type * as http from "../http.js";
+
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+declare const fullApi: ApiFromModules<{
+  auth: typeof auth;
+  functions: typeof functions;
+  http: typeof http;
+}>;
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;

--- a/convex/_generated/api.js
+++ b/convex/_generated/api.js
@@ -1,0 +1,22 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi } from "convex/server";
+
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api = anyApi;
+export const internal = anyApi;

--- a/convex/_generated/dataModel.d.ts
+++ b/convex/_generated/dataModel.d.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/convex/_generated/server.d.ts
+++ b/convex/_generated/server.d.ts
@@ -1,0 +1,142 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const query: QueryBuilder<DataModel, "public">;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const mutation: MutationBuilder<DataModel, "public">;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export declare const action: ActionBuilder<DataModel, "public">;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+
+/**
+ * Define an HTTP action.
+ *
+ * This function will be used to respond to HTTP requests received by a Convex
+ * deployment if the requests matches the path and method where this action
+ * is routed. Be sure to route your action in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export declare const httpAction: HttpActionBuilder;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * This differs from the {@link MutationCtx} because all of the services are
+ * read-only.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/convex/_generated/server.js
+++ b/convex/_generated/server.js
@@ -1,0 +1,89 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery = internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation = internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction = internalActionGeneric;
+
+/**
+ * Define a Convex HTTP action.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument, and a `Request` object
+ * as its second.
+ * @returns The wrapped endpoint function. Route a URL path to this function in `convex/http.js`.
+ */
+export const httpAction = httpActionGeneric;

--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -126,10 +126,9 @@ export const getSessionMessages = query({
       .query("session_messages")
       .withIndex("by_session_turn", (q) => q.eq("session_id", sessionId));
     if (beforeTurnNo !== undefined) {
-      q = q.lt("turn_no", beforeTurnNo);
+      q = q.filter((f) => f.lt(f.field("turn_no"), beforeTurnNo));
     }
-    q = q.order("desc");
-    const rows = await q.take(limit ?? 50);
+    const rows = await q.order("desc").take(limit ?? 50);
     rows.reverse();
     return rows.map((r) => ({ ...r }));
   },
@@ -205,7 +204,7 @@ export const getBoardSummary = query({
     }
 
     const objMap = ydoc.getMap<any>('objects');
-    const objects = Array.from(objMap.values());
+    const objects = Array.from(objMap.values()) as any[];
     const byKind: Record<string, number> = {};
     const byOwner: Record<string, number> = {};
     const learnerTags: any[] = [];
@@ -240,7 +239,7 @@ export const getBoardSummary = query({
     });
 
     const ephMap = ydoc.getMap<any>('ephemeral');
-    const ephObjs = Array.from(ephMap.values());
+    const ephObjs = Array.from(ephMap.values()) as any[];
     const activeHighlights = ephObjs.filter((s) => s.kind === 'highlight_stroke').length;
     const activeQuestionTags = ephObjs
       .filter((s) => s.kind === 'question_tag')
@@ -298,12 +297,13 @@ export const getWhiteboardSnapshots = query({
     if (!session || session.user_id !== identity.subject) return [];
     let q = ctx.db
       .query('whiteboard_snapshots')
-      .withIndex('by_session_snapshot', (q) => q.eq('session_id', sessionId));
+      .withIndex('by_session_snapshot', (q) =>
+        q.eq('session_id', sessionId)
+      );
     if (maxIndex !== undefined) {
-      q = q.lte('snapshot_index', maxIndex);
+      q = q.filter((f) => f.lte(f.field('snapshot_index'), maxIndex));
     }
-    q = q.order('asc');
-    return await q.collect();
+    return await q.order('asc').collect();
   },
 });
 

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,6 +1,7 @@
 import { httpRouter } from "convex/server";
 import { httpAction } from "./_generated/server";
 import { api } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
 import { auth } from "./auth";
 
 const http = httpRouter();
@@ -31,7 +32,10 @@ http.route({
   method: "POST",
   handler: httpAction(async ({ runMutation }, request) => {
     const { folderId, name } = await request.json();
-    await runMutation(api.functions.renameFolder, { folderId, name });
+    await runMutation(api.functions.renameFolder, {
+      folderId: folderId as Id<'folders'>,
+      name,
+    });
     return new Response(null, { status: 200 });
   }),
 });
@@ -41,7 +45,9 @@ http.route({
   method: "POST",
   handler: httpAction(async ({ runMutation }, request) => {
     const { folderId } = await request.json();
-    await runMutation(api.functions.deleteFolder, { folderId });
+    await runMutation(api.functions.deleteFolder, {
+      folderId: folderId as Id<'folders'>,
+    });
     return new Response(null, { status: 200 });
   }),
 });
@@ -53,7 +59,9 @@ http.route({
     const url = new URL(request.url);
     const folderId = url.searchParams.get("folderId");
     if (!folderId) return new Response("Missing folderId", { status: 400 });
-    const folder = await runQuery(api.functions.getFolder, { folderId });
+    const folder = await runQuery(api.functions.getFolder, {
+      folderId: folderId as Id<'folders'>,
+    });
     if (!folder) return new Response("Not found", { status: 404 });
     return new Response(JSON.stringify(folder), { status: 200 });
   }),
@@ -64,7 +72,9 @@ http.route({
   method: "POST",
   handler: httpAction(async ({ runMutation }, request) => {
     const body = await request.json();
-    const result = await runMutation(api.functions.createSession, { folderId: body.folderId ?? undefined });
+    const result = await runMutation(api.functions.createSession, {
+      folderId: body.folderId as Id<'folders'> | undefined,
+    });
     return new Response(JSON.stringify(result), { status: 201 });
   }),
 });
@@ -79,7 +89,7 @@ http.route({
     const beforeTurnNo = url.searchParams.get("beforeTurnNo");
     const limit = url.searchParams.get("limit");
     const rows = await runQuery(api.functions.getSessionMessages, {
-      sessionId,
+      sessionId: sessionId as Id<'sessions'>,
       beforeTurnNo: beforeTurnNo ? Number(beforeTurnNo) : undefined,
       limit: limit ? Number(limit) : undefined,
     });
@@ -93,7 +103,7 @@ http.route({
   handler: httpAction(async ({ runMutation }, request) => {
     const body = await request.json();
     await runMutation(api.functions.updateSessionContext, {
-      sessionId: body.sessionId,
+      sessionId: body.sessionId as Id<'sessions'>,
       context: body.context,
     });
     return new Response(null, { status: 200 });
@@ -107,7 +117,9 @@ http.route({
     const url = new URL(request.url);
     const sessionId = url.searchParams.get("sessionId");
     if (!sessionId) return new Response("Missing sessionId", { status: 400 });
-    const data = await runQuery(api.functions.getSessionContext, { sessionId });
+    const data = await runQuery(api.functions.getSessionContext, {
+      sessionId: sessionId as Id<'sessions'>,
+    });
     if (!data) return new Response("Not found", { status: 404 });
     return new Response(JSON.stringify(data), { status: 200 });
   }),
@@ -120,7 +132,9 @@ http.route({
     const url = new URL(request.url);
     const sessionId = url.searchParams.get("sessionId");
     if (!sessionId) return new Response("Missing sessionId", { status: 400 });
-    const summary = await runQuery(api.functions.getBoardSummary, { sessionId });
+    const summary = await runQuery(api.functions.getBoardSummary, {
+      sessionId: sessionId as Id<'sessions'>,
+    });
     return new Response(JSON.stringify(summary), { status: 200 });
   }),
 });
@@ -131,7 +145,7 @@ http.route({
   handler: httpAction(async ({ runMutation }, request) => {
     const body = await request.json();
     await runMutation(api.functions.insertSnapshot, {
-      sessionId: body.sessionId,
+      sessionId: body.sessionId as Id<'sessions'>,
       snapshotIndex: body.snapshotIndex,
       actionsJson: body.actionsJson,
     });
@@ -148,7 +162,7 @@ http.route({
     if (!sessionId) return new Response("Missing sessionId", { status: 400 });
     const maxIndex = url.searchParams.get("maxIndex");
     const rows = await runQuery(api.functions.getWhiteboardSnapshots, {
-      sessionId,
+      sessionId: sessionId as Id<'sessions'>,
       maxIndex: maxIndex ? Number(maxIndex) : undefined,
     });
     return new Response(JSON.stringify(rows), { status: 200 });
@@ -161,7 +175,7 @@ http.route({
   handler: httpAction(async ({ runMutation }, request) => {
     const body = await request.json();
     const result = await runMutation(api.functions.uploadSessionDocuments, {
-      sessionId: body.sessionId,
+      sessionId: body.sessionId as Id<'sessions'>,
       filenames: body.filenames ?? [],
     });
     return new Response(JSON.stringify(result), { status: 200 });
@@ -175,7 +189,9 @@ http.route({
     const url = new URL(request.url);
     const sessionId = url.searchParams.get("sessionId");
     if (!sessionId) return new Response("Missing sessionId", { status: 400 });
-    const result = await runQuery(api.functions.getSessionAnalysis, { sessionId });
+    const result = await runQuery(api.functions.getSessionAnalysis, {
+      sessionId: sessionId as Id<'sessions'>,
+    });
     return new Response(JSON.stringify(result), { status: 200 });
   }),
 });

--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -18,7 +18,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "types": ["node"],
-    "typeRoots": ["../frontend/node_modules/@types"]
+    "typeRoots": ["../frontend/node_modules/@types", "../frontend/node_modules"]
   },
   "include": ["./**/*"],
   "exclude": ["./_generated"]

--- a/convex/types.d.ts
+++ b/convex/types.d.ts
@@ -1,0 +1,27 @@
+declare module 'redis' {
+  export function createClient(options?: any): {
+    connect(): Promise<void>;
+    getBuffer(key: string): Promise<Buffer | null>;
+    quit(): Promise<void>;
+  };
+}
+
+declare module 'ws' {
+  export type RawData = Buffer | ArrayBuffer | Buffer[];
+  export class WebSocket {
+    static readonly OPEN: number;
+    readyState: number;
+    send(data: RawData, opts?: any): void;
+    on(event: 'message', listener: (data: RawData, isBinary: boolean) => void): void;
+    on(event: 'close', listener: () => void): void;
+  }
+  export class WebSocketServer {
+    constructor(options: any);
+    handleUpgrade(
+      req: import('http').IncomingMessage,
+      socket: any,
+      head: Buffer,
+      cb: (ws: WebSocket) => void
+    ): void;
+  }
+}

--- a/convex/wsServer.ts
+++ b/convex/wsServer.ts
@@ -1,5 +1,5 @@
 import http from 'http';
-import { WebSocketServer, WebSocket } from 'ws';
+import { WebSocketServer, WebSocket, RawData } from 'ws';
 
 const port = Number(process.env.WS_PORT || 8080);
 const server = http.createServer();
@@ -7,7 +7,7 @@ const server = http.createServer();
 // Map sessionId -> set of WebSocket connections
 const sessions = new Map<string, Set<WebSocket>>();
 
-function broadcast(sessionId: string, data: WebSocket.RawData, origin: WebSocket) {
+function broadcast(sessionId: string, data: RawData, origin: WebSocket) {
   const peers = sessions.get(sessionId);
   if (!peers) return;
   for (const ws of peers) {


### PR DESCRIPTION
## Summary
- add generated Convex typings for backend build
- refine queries to avoid type errors
- cast id parameters in HTTP routes
- add stubs for `redis` and `ws`
- update Convex tsconfig

## Testing
- `npx tsc -p convex/tsconfig.json`
- `pnpm lint` *(fails: The requested module '@eslint/eslintrc' does not provide an export named 'createConfig')*