### PR TITLE
[convex] add startSession alias

### DIFF
--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -113,6 +113,9 @@ export const createSession = mutation({
   },
 });
 
+// Alias for backwards compatibility with existing frontend calls
+export const startSession = createSession;
+
 export const getSessionMessages = query({
   args: {
     sessionId: v.id("sessions"),


### PR DESCRIPTION
## Summary
- expose `startSession` in Convex functions to match frontend API

## Testing
- `pytest` *(fails: AttributeError: 'function' object has no attribute 'name')*
- `npm run lint`