### PR TITLE
[frontend] update upload documents for convex

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,3 +1,4 @@
-NEXT_PUBLIC_API_BASE_URL="http://localhost:8000/api/v1"
+# Endpoint for Convex HTTP routes
+NEXT_PUBLIC_API_BASE_URL="http://localhost:4000"
 NEXT_PUBLIC_CONVEX_URL="YOUR_CONVEX_URL"
 NEXT_PUBLIC_CONVEX_SITE_URL="http://localhost:3000"


### PR DESCRIPTION
## Summary
- adjust default API URL to convex proxy
- modify uploadDocuments to use Convex HTTP route
- update environment example

## Testing
- `npm run lint` *(fails: The requested module '@eslint/eslintrc' does not provide an export named 'createConfig')*
- `pytest` *(fails: 7 errors during collection)*