### PR TITLE
[frontend] use convex mutation for document upload

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -77,12 +77,12 @@ export const uploadDocuments = async (
     console.log(
       `Recording ${filenames.length} document(s) for session ${sessionId} via Convex...`,
     );
-    const response = await apiClient.post<UploadDocumentsResponse>(
-      '/uploadSessionDocuments',
-      { sessionId, filenames },
+    const result = await convex.mutation(
+      convexApi.functions.uploadSessionDocuments,
+      { sessionId, filenames }
     );
-    console.log('Upload recorded:', response.data);
-    return response.data;
+    console.log('Upload recorded:', result);
+    return result as UploadDocumentsResponse;
   } catch (error) {
     console.error('Error uploading documents:', error);
     throw error;


### PR DESCRIPTION
## Summary
- update frontend uploadDocuments to call convex mutation instead of local HTTP

## Testing
- `npm run lint` *(fails: The requested module '@eslint/eslintrc' does not provide an export named 'createConfig')*
- `pytest` *(fails: ImportError and AttributeError during tests setup)*