### PR TITLE
[frontend] guard canvas clearing

### DIFF
--- a/frontend/src/contexts/WhiteboardProvider.tsx
+++ b/frontend/src/contexts/WhiteboardProvider.tsx
@@ -649,8 +649,12 @@ export const WhiteboardProvider: React.FC<{ children: ReactNode }> = ({ children
              // @ts-expect-error - handle CLEAR_CANVAS variant
              case 'CLEAR_CANVAS':
                console.log("[WhiteboardProvider] Clearing whiteboard (CLEAR_CANVAS)");
-               fabricCanvasInternalState.clear();
-               requiresRender = true;
+               if ((fabricCanvasInternalState as any).contextContainer) {
+                 fabricCanvasInternalState.clear();
+                 requiresRender = true;
+               } else {
+                 console.warn('[WhiteboardProvider] CLEAR_CANVAS attempted but canvas context is not available.');
+               }
                break;
              case 'GROUP_OBJECTS': {
                 const objectsToGroup = fabricCanvasInternalState.getObjects().filter((obj: any) => 


### PR DESCRIPTION
## Summary
- prevent crashing when clearing whiteboard before Fabric canvas is ready

## Testing
- `pnpm lint` *(fails: The requested module '@eslint/eslintrc' does not provide an export named 'createConfig')*
- `pytest` *(fails: 7 errors during collection)*